### PR TITLE
feat: distributed segment requests

### DIFF
--- a/demo/config.js
+++ b/demo/config.js
@@ -476,6 +476,7 @@ shakaDemo.Config = class {
         .addNumberInput_('Inaccurate Manifest Tolerance',
             'streaming.inaccurateManifestTolerance',
             /* canBeDecimal= */ true)
+        .addBoolInput_('Randomly distributed segment requests', 'streaming.distributedRequests')
         .addBoolInput_('Low Latency Mode', 'streaming.lowLatencyMode')
         .addBoolInput_('Auto Low Latency Mode', 'streaming.autoLowLatencyMode')
         .addBoolInput_('Force HTTP', 'streaming.forceHTTP')

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1530,6 +1530,7 @@ shaka.extern.LiveSyncConfiguration;
 
 /**
  * @typedef {{
+ *   distributedRequests: boolean,
  *   retryParameters: shaka.extern.RetryParameters,
  *   failureCallback: function(!shaka.util.Error),
  *   rebufferingGoal: number,
@@ -1581,6 +1582,8 @@ shaka.extern.LiveSyncConfiguration;
  * @description
  * The StreamingEngine's configuration options.
  *
+ * @property {boolean} distributedRequests
+ *   Randomly distribute segment requests.
  * @property {shaka.extern.RetryParameters} retryParameters
  *   Retry parameters for segment requests.
  * @property {function(!shaka.util.Error)} failureCallback

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -2442,7 +2442,7 @@ shaka.media.StreamingEngine = class {
           reference, streamDataCallback);
     }
     if (!op) {
-      if (reference instanceof shaka.media.SegmentReference) {
+      if (reference instanceof shaka.media.SegmentReference && this.config_.distributedRequests === true) {
         const segmentDuration = reference.endTime - reference.startTime;
         const dispatchPromise = new Promise((resolve) => {
           new shaka.util.Timer(() => {

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -33,6 +33,7 @@ goog.require('shaka.util.MimeUtils');
 goog.require('shaka.util.Mp4BoxParsers');
 goog.require('shaka.util.Mp4Parser');
 goog.require('shaka.util.Networking');
+goog.require('shaka.util.Timer');
 
 
 /**
@@ -2441,8 +2442,19 @@ shaka.media.StreamingEngine = class {
           reference, streamDataCallback);
     }
     if (!op) {
-      op = this.dispatchFetch_(
+      if (reference instanceof shaka.media.SegmentReference) {
+        const segmentDuration = reference.endTime - reference.startTime;
+        const dispatchPromise = new Promise((resolve) => {
+          new shaka.util.Timer(() => {
+            resolve(this.dispatchFetch_(
+              reference, mediaState.stream, streamDataCallback));
+          }).tickAfter(Math.random() * segmentDuration / 2);
+        });
+        op = await dispatchPromise;
+      } else {
+        op = this.dispatchFetch_(
           reference, mediaState.stream, streamDataCallback);
+      }
     }
 
     let position = 0;

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -191,6 +191,7 @@ shaka.util.PlayerConfiguration = class {
     };
 
     const streaming = {
+      distributedRequests: false,
       retryParameters: shaka.net.NetworkingEngine.defaultRetryParameters(),
       // Need some operation in the callback or else closure may remove calls
       // to the function as it would be a no-op.  The operation can't just be a

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -984,6 +984,36 @@ describe('StreamingEngine', () => {
     });
   });
 
+  it('applies a small random delay to segment requests', async () => {
+    setupVod();
+    mediaSourceEngine =
+        new shaka.test.FakeMediaSourceEngine(segmentData);
+    const config = shaka.util.PlayerConfiguration.createDefault().streaming;
+    config.distributedRequests = true;
+    createStreamingEngine(config);
+
+    // Here we go!
+    streamingEngine.switchVariant(variant);
+    streamingEngine.switchTextStream(textStream);
+    await streamingEngine.start();
+    playing = true;
+
+    await runTest();
+    expect(mediaSourceEngine.endOfStream).toHaveBeenCalled();
+
+    // Verify buffers.
+    expect(mediaSourceEngine.initSegments).toEqual({
+      audio: [false, true],
+      video: [false, true],
+      text: [],
+    });
+    expect(mediaSourceEngine.segments).toEqual({
+      audio: [true, true, true, true],
+      video: [true, true, true, true],
+      text: [true, true, true, true],
+    });
+  });
+
   describe('switchVariant/switchTextStream', () => {
     let initialVariant;
     let sameAudioVariant;


### PR DESCRIPTION
This PR introduces a new feature that enables the random distribution of media segments for easing the load on cdns.

# Summary:

* Updated the player settings: added the boolean streaming.distributedRequests.
* Implemented segment request randomization by adding a delay when fetching media segments. The delay can be up to half of the segment duration.
* Updated unit testing to contemplate the new feature.

# Testing:

* Verified the correct functioning of the player with the feature enabled.
* Verified that the segments are being fetched at random intervals within their availability window.
* Verified that the feature doesn't impact the viewing experience. Tested VOD and live content.

# How to test manually:

Set the following configuration to the player:
```
player.configure({
    streaming: {
        distributedRequests: true
    }
});
```