### PR TITLE
Feat/response received

### DIFF
--- a/demo/common/assets.js
+++ b/demo/common/assets.js
@@ -911,6 +911,31 @@ shakaAssets.testAssets = [
         },
       }),
   new ShakaDemoAssetInfo(
+      /* name= */ 'Tears of Steel (HLS AVC - FairPlay - SingleKey)',
+      /* iconUri= */ 'https://storage.googleapis.com/shaka-asset-icons/tears_of_steel.png',
+      /* manifestUri= */ 'https://media.axprod.net/TestVectors/Hls/protected_hls_1080p_h264_singlekey/manifest.m3u8',
+      /* source= */ shakaAssets.Source.AXINOM)
+      .addKeySystem(shakaAssets.KeySystem.FAIRPLAY)
+      .addFeature(shakaAssets.Feature.HLS)
+      .addFeature(shakaAssets.Feature.HIGH_DEFINITION)
+      .addFeature(shakaAssets.Feature.MP4)
+      .addFeature(shakaAssets.Feature.MULTIPLE_LANGUAGES)
+      .addFeature(shakaAssets.Feature.SUBTITLES)
+      .addLicenseServer('com.apple.fps', 'https://drm-fairplay-licensing.axprod.net/AcquireLicense')
+      .setExtraConfig({
+        drm: {
+          advanced: {
+            'com.apple.fps': {
+              serverCertificateUri: 'https://vtb.axinom.com/FPScert/fairplay.cer',
+              headers: {
+                // cspell: disable-next-line
+                'X-AxDRM-Message': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJ2ZXJzaW9uIjogMSwKICAiY29tX2tleV9pZCI6ICI2OWU1NDA4OC1lOWUwLTQ1MzAtOGMxYS0xZWI2ZGNkMGQxNGUiLAogICJtZXNzYWdlIjogewogICAgInR5cGUiOiAiZW50aXRsZW1lbnRfbWVzc2FnZSIsCiAgICAidmVyc2lvbiI6IDIsCiAgICAibGljZW5zZSI6IHsKICAgICAgImFsbG93X3BlcnNpc3RlbmNlIjogdHJ1ZQogICAgfSwKICAgICJjb250ZW50X2tleXNfc291cmNlIjogewogICAgICAiaW5saW5lIjogWwogICAgICAgIHsKICAgICAgICAgICJpZCI6ICI0MDYwYTg2NS04ODc4LTQyNjctOWNiZi05MWFlNWJhZTFlNzIiLAogICAgICAgICAgImVuY3J5cHRlZF9rZXkiOiAid3QzRW51dVI1UkFybjZBRGYxNkNCQT09IiwKICAgICAgICAgICJ1c2FnZV9wb2xpY3kiOiAiUG9saWN5IEEiCiAgICAgICAgfQogICAgICBdCiAgICB9LAogICAgImNvbnRlbnRfa2V5X3VzYWdlX3BvbGljaWVzIjogWwogICAgICB7CiAgICAgICAgIm5hbWUiOiAiUG9saWN5IEEiLAogICAgICAgICJwbGF5cmVhZHkiOiB7CiAgICAgICAgICAibWluX2RldmljZV9zZWN1cml0eV9sZXZlbCI6IDE1MCwKICAgICAgICAgICJwbGF5X2VuYWJsZXJzIjogWwogICAgICAgICAgICAiNzg2NjI3RDgtQzJBNi00NEJFLThGODgtMDhBRTI1NUIwMUE3IgogICAgICAgICAgXQogICAgICAgIH0KICAgICAgfQogICAgXQogIH0KfQ.l8PnZznspJ6lnNmfAE9UQV532Ypzt1JXQkvrk8gFSRw',
+              },
+            },
+          },
+        },
+      }),
+  new ShakaDemoAssetInfo(
       /* name= */ 'Tears of Steel (HLS AVC - FairPlay - MultiKey)',
       /* iconUri= */ 'https://storage.googleapis.com/shaka-asset-icons/tears_of_steel.png',
       /* manifestUri= */ 'https://media.axprod.net/TestVectors/MultiKey/Hls_h264_1080p_cenc/manifest.m3u8',
@@ -935,9 +960,8 @@ shakaAssets.testAssets = [
           },
         },
       }),
-  // End A
   new ShakaDemoAssetInfo(
-      /* name= */ 'Tears of Steel (HLS HEVC - FairPlay)',
+      /* name= */ 'Tears of Steel (HLS HEVC - FairPlay - SingleKey)',
       /* iconUri= */ 'https://storage.googleapis.com/shaka-asset-icons/tears_of_steel.png',
       /* manifestUri= */ 'https://media.axprod.net/TestVectors/H265/protected_hls_1080p_h265_singlekey/manifest.m3u8',
       /* source= */ shakaAssets.Source.AXINOM)
@@ -956,6 +980,31 @@ shakaAssets.testAssets = [
               headers: {
                 // cspell: disable-next-line
                 'X-AxDRM-Message': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJ2ZXJzaW9uIjogMSwKICAiY29tX2tleV9pZCI6ICI2OWU1NDA4OC1lOWUwLTQ1MzAtOGMxYS0xZWI2ZGNkMGQxNGUiLAogICJtZXNzYWdlIjogewogICAgInR5cGUiOiAiZW50aXRsZW1lbnRfbWVzc2FnZSIsCiAgICAidmVyc2lvbiI6IDIsCiAgICAibGljZW5zZSI6IHsKICAgICAgImFsbG93X3BlcnNpc3RlbmNlIjogdHJ1ZQogICAgfSwKICAgICJjb250ZW50X2tleXNfc291cmNlIjogewogICAgICAiaW5saW5lIjogWwogICAgICAgIHsKICAgICAgICAgICJpZCI6ICI5ZmQzODVkNS1mMzg5LTQ4YjUtYjdjMy1iMTg2M2VlMTA4ODgiLAogICAgICAgICAgImVuY3J5cHRlZF9rZXkiOiAiS3ZhaytZZVF1NGU2QnRvcEQ2Wm1JUT09IiwKICAgICAgICAgICJ1c2FnZV9wb2xpY3kiOiAiUG9saWN5IEEiCiAgICAgICAgfQogICAgICBdCiAgICB9LAogICAgImNvbnRlbnRfa2V5X3VzYWdlX3BvbGljaWVzIjogWwogICAgICB7CiAgICAgICAgIm5hbWUiOiAiUG9saWN5IEEiLAogICAgICAgICJwbGF5cmVhZHkiOiB7CiAgICAgICAgICAibWluX2RldmljZV9zZWN1cml0eV9sZXZlbCI6IDE1MCwKICAgICAgICAgICJwbGF5X2VuYWJsZXJzIjogWwogICAgICAgICAgICAiNzg2NjI3RDgtQzJBNi00NEJFLThGODgtMDhBRTI1NUIwMUE3IgogICAgICAgICAgXQogICAgICAgIH0KICAgICAgfQogICAgXQogIH0KfQ.CNEEm6UhOFiXadbcxQrs64NEb9ys7YdPZ7TmTO8aTbg',
+              },
+            },
+          },
+        },
+      }),
+  new ShakaDemoAssetInfo(
+      /* name= */ 'Tears of Steel (HLS HEVC - FairPlay - MultiKey)',
+      /* iconUri= */ 'https://storage.googleapis.com/shaka-asset-icons/tears_of_steel.png',
+      /* manifestUri= */ 'https://media.axprod.net/TestVectors/H265/protected_hls_1080p_h265_multikey/manifest.m3u8',
+      /* source= */ shakaAssets.Source.AXINOM)
+      .addKeySystem(shakaAssets.KeySystem.FAIRPLAY)
+      .addFeature(shakaAssets.Feature.HLS)
+      .addFeature(shakaAssets.Feature.HIGH_DEFINITION)
+      .addFeature(shakaAssets.Feature.MP4)
+      .addFeature(shakaAssets.Feature.MULTIPLE_LANGUAGES)
+      .addFeature(shakaAssets.Feature.SUBTITLES)
+      .addLicenseServer('com.apple.fps', 'https://drm-fairplay-licensing.axprod.net/AcquireLicense')
+      .setExtraConfig({
+        drm: {
+          advanced: {
+            'com.apple.fps': {
+              serverCertificateUri: 'https://vtb.axinom.com/FPScert/fairplay.cer',
+              headers: {
+                // cspell: disable-next-line
+                'X-AxDRM-Message': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJ2ZXJzaW9uIjogMSwKICAiY29tX2tleV9pZCI6ICI2OWU1NDA4OC1lOWUwLTQ1MzAtOGMxYS0xZWI2ZGNkMGQxNGUiLAogICJtZXNzYWdlIjogewogICAgInR5cGUiOiAiZW50aXRsZW1lbnRfbWVzc2FnZSIsCiAgICAidmVyc2lvbiI6IDIsCiAgICAibGljZW5zZSI6IHsKICAgICAgImFsbG93X3BlcnNpc3RlbmNlIjogdHJ1ZQogICAgfSwKICAgICJjb250ZW50X2tleXNfc291cmNlIjogewogICAgICAiaW5saW5lIjogWwogICAgICAgIHsKICAgICAgICAgICJpZCI6ICIzMWJiNjViNC01ODMxLTRjMzQtOTExNC0yNTU5MWJhZTQwNjYiLAogICAgICAgICAgImVuY3J5cHRlZF9rZXkiOiAiWTV2ZDB2aWpvbDExVHFMKytBTFpNZz09IiwKICAgICAgICAgICJ1c2FnZV9wb2xpY3kiOiAiUG9saWN5IEEiCiAgICAgICAgfSwKICAgICAgICB7CiAgICAgICAgICAiaWQiOiAiZDVlM2YzNjctZmM5Ny00Njg1LWFjM2QtMmNjYWI0ZTAxNDhhIiwKICAgICAgICAgICJlbmNyeXB0ZWRfa2V5IjogInhwM1l6TWpQTkFDT2FSeEoxRnJiV3c9PSIsCiAgICAgICAgICAidXNhZ2VfcG9saWN5IjogIlBvbGljeSBBIgogICAgICAgIH0sCiAgICAgICAgewogICAgICAgICAgImlkIjogIjk4MjkzYWE1LWE2M2QtNDA1Ni1hZWI1LWI4ZWJmMmIyMjM3MCIsCiAgICAgICAgICAiZW5jcnlwdGVkX2tleSI6ICJYZmpUZkFqZjYxSk9JK1BuM0hIV0dnPT0iLAogICAgICAgICAgInVzYWdlX3BvbGljeSI6ICJQb2xpY3kgQSIKICAgICAgICB9CiAgICAgIF0KICAgIH0sCiAgICAiY29udGVudF9rZXlfdXNhZ2VfcG9saWNpZXMiOiBbCiAgICAgIHsKICAgICAgICAibmFtZSI6ICJQb2xpY3kgQSIsCiAgICAgICAgInBsYXlyZWFkeSI6IHsKICAgICAgICAgICJtaW5fZGV2aWNlX3NlY3VyaXR5X2xldmVsIjogMTUwLAogICAgICAgICAgInBsYXlfZW5hYmxlcnMiOiBbCiAgICAgICAgICAgICI3ODY2MjdEOC1DMkE2LTQ0QkUtOEY4OC0wOEFFMjU1QjAxQTciCiAgICAgICAgICBdCiAgICAgICAgfQogICAgICB9CiAgICBdCiAgfQp9.8U5sx_tcQOUb86cjqkd5e2leudsnT4BpzY0zTTVAKcA',
               },
             },
           },

--- a/lib/util/cmcd_manager.js
+++ b/lib/util/cmcd_manager.js
@@ -163,7 +163,7 @@ shaka.util.CmcdManager = class {
 
     if (this.playbackStarted_ && buffering) {
       this.starved_ = true;
-      this.reportEvent_('ps', {sta: 'r'});
+      this.reportEvent_('ps', {'sta': 'r'});
     }
 
     this.buffering_ = buffering;
@@ -203,7 +203,7 @@ shaka.util.CmcdManager = class {
       return;
     }
 
-    this.reportEvent_('ps', {sta: 'd'});
+    this.reportEvent_('ps', {'sta': 'd'});
     if (this.video_ && this.video_.autoplay) {
       const playResult = this.video_.play();
       if (playResult) {
@@ -497,7 +497,7 @@ shaka.util.CmcdManager = class {
   onPlaybackPlay_() {
     if (!this.playbackPlayTime_) {
       this.playbackPlayTime_ = Date.now();
-      this.reportEvent_('ps', {sta: 's'});
+      this.reportEvent_('ps', {'sta': 's'});
     }
   }
 
@@ -519,7 +519,7 @@ shaka.util.CmcdManager = class {
     this.eventManager_.listen(
         this.video_, 'playing', () => {
           this.onPlaybackPlaying_();
-          this.reportEvent_('ps', {sta: 'p'});
+          this.reportEvent_('ps', {'sta': 'p'});
         },
     );
 
@@ -535,17 +535,17 @@ shaka.util.CmcdManager = class {
 
     // Pause
     this.eventManager_.listen(this.video_, 'pause', () => {
-      this.reportEvent_('ps', {sta: 'a'});
+      this.reportEvent_('ps', {'sta': 'a'});
     });
 
     // Waiting
     this.eventManager_.listen(this.player_, 'buffering', () => {
-      this.reportEvent_('ps', {sta: 'w'});
+      this.reportEvent_('ps', {'sta': 'w'});
     });
 
     // Seeking
     this.eventManager_.listen(this.video_, 'seeking', () =>
-      this.reportEvent_('ps', {sta: 'k'}),
+      this.reportEvent_('ps', {'sta': 'k'}),
     );
 
     // Fullscreen/PiP Change (Player Expand/Collapse)
@@ -590,14 +590,14 @@ shaka.util.CmcdManager = class {
     // Background Mode
     this.eventManager_.listen(document, 'visibilitychange', () => {
       if (document.hidden) {
-        this.reportEvent_('b', {bg: true});
+        this.reportEvent_('b', {'bg': true});
       } else {
         this.reportEvent_('b');
       }
     });
 
     this.eventManager_.listen(this.player_, 'complete', () => {
-      this.reportEvent_('ps', {sta: 'e'});
+      this.reportEvent_('ps', {'sta': 'e'});
     });
   }
 
@@ -701,7 +701,6 @@ shaka.util.CmcdManager = class {
     };
 
     const eventData = Object.assign(baseEventData, extraData);
-
     const rawOutput = this.getGenericData_(eventData,
         shaka.util.CmcdManager.CmcdMode.EVENT);
 

--- a/lib/util/cmcd_manager.js
+++ b/lib/util/cmcd_manager.js
@@ -731,6 +731,10 @@ shaka.util.CmcdManager = class {
         allowedKeysEventMode.push(shaka.util.CmcdManager.CmcdV2Keys.TIMESTAMP);
       }
 
+      if (!allowedKeysEventMode.includes('e')) {
+        allowedKeysEventMode.push('e');
+      }
+
       const targetKey = this.getCmcdTargetHash_(target);
       if (!this.cmcdSequenceNumbers_[targetKey]) {
         this.cmcdSequenceNumbers_[targetKey] = {request: 1, response: 1};

--- a/lib/util/cmcd_manager.js
+++ b/lib/util/cmcd_manager.js
@@ -271,9 +271,10 @@ shaka.util.CmcdManager = class {
    *   The request context
    */
   applyResponseData(type, response, context = {}) {
-    if (this.getEventModeEnabledTargets_().length === 0) {
+    if (!this.hasResponseReceived_()) {
       return;
     }
+
     const RequestType = shaka.net.NetworkingEngine.RequestType;
 
     switch (type) {
@@ -665,7 +666,8 @@ shaka.util.CmcdManager = class {
       return false;
     }
     return targets.some(
-        (target) => target.events && target.events.includes('rr'));
+        (target) => target.events &&
+          target.events.includes('rr') && target.enabled);
   }
 
   /**

--- a/lib/util/cmcd_manager.js
+++ b/lib/util/cmcd_manager.js
@@ -80,11 +80,10 @@ shaka.util.CmcdManager = class {
     this.startTimeOfLoad_ = 0;
 
     /**
-     * @private {{request: boolean, response: boolean, event: boolean}}
+     * @private {{request: boolean, event: boolean}}
      */
     this.msdSent_ = {
       request: false,
-      response: false,
       event: false,
     };
 
@@ -272,7 +271,7 @@ shaka.util.CmcdManager = class {
    *   The request context
    */
   applyResponseData(type, response, context = {}) {
-    if (this.getResponseModeEnabledTargets().length === 0) {
+    if (this.getEventModeEnabledTargets_().length === 0) {
       return;
     }
     const RequestType = shaka.net.NetworkingEngine.RequestType;
@@ -336,11 +335,21 @@ shaka.util.CmcdManager = class {
       data.url = this.removeCmcdQueryFromUri_(
           originalRequestUrl);
 
+      data.rc = response.status || 0;
+
       if (this.requestTimestampMap_.has(response.originalRequest)) {
         data.ts = this.requestTimestampMap_.get(response.originalRequest);
         this.requestTimestampMap_.delete(response.originalRequest);
       } else if (!data.ts) {
         data.ts = Date.now();
+      }
+
+      if (response.headers && response.headers['CMSD-Static']) {
+        data.cmsds = btoa(response.headers['CMSD-Static']);
+      }
+
+      if (response.headers && response.headers['CMSD-Dynamic']) {
+        data.cmsdd = btoa(response.headers['CMSD-Dynamic']);
       }
 
       this.applyResponse_(response, data);
@@ -643,21 +652,20 @@ shaka.util.CmcdManager = class {
       return [];
     }
     return targets.filter(
-        (target) => target.mode === shaka.util.CmcdManager.CmcdMode.EVENT &&
-            target.enabled);
+        (target) => target.enabled);
   }
 
   /**
-   * @return {!Array<shaka.extern.CmcdTarget>}
+   * @return {boolean}
+   * @private
    */
-  getResponseModeEnabledTargets() {
+  hasResponseReceived_() {
     const targets = this.config_.targets;
     if (!targets) {
-      return [];
+      return false;
     }
-    return targets.filter(
-        (target) => target.mode === shaka.util.CmcdManager.CmcdMode.RESPONSE &&
-            target.enabled === true);
+    return targets.some(
+        (target) => target.events && target.events.includes('rr'));
   }
 
   /**
@@ -705,7 +713,7 @@ shaka.util.CmcdManager = class {
 
     const allowedKeys = Array.from(new Set([
       ...shaka.util.CmcdManager.CmcdKeys.V2CommonKeys,
-      ...shaka.util.CmcdManager.CmcdKeys.V2EventKeys,
+      ...shaka.util.CmcdManager.CmcdKeys.V2EventModeKeys,
     ]));
 
     for (const target of eventTargets) {
@@ -720,6 +728,13 @@ shaka.util.CmcdManager = class {
           shaka.util.CmcdManager.CmcdV2Keys.TIMESTAMP)) {
         allowedKeysEventMode.push(shaka.util.CmcdManager.CmcdV2Keys.TIMESTAMP);
       }
+
+      const targetKey = this.getCmcdTargetHash_(target);
+      if (!this.cmcdSequenceNumbers_[targetKey]) {
+        this.cmcdSequenceNumbers_[targetKey] = {request: 1, response: 1};
+      }
+
+      rawOutput.sn = this.cmcdSequenceNumbers_[targetKey].response++;
 
       const output = this.filterKeys_(rawOutput, allowedKeysEventMode);
 
@@ -791,53 +806,7 @@ shaka.util.CmcdManager = class {
    * @private
    */
   applyResponse_(response, data) {
-    const responseTargets = this.getResponseModeEnabledTargets();
-    if (responseTargets.length === 0) {
-      return;
-    }
-
-    const version = this.config_.version;
-    const allowedKeys = (version == shaka.util.CmcdManager.Version.VERSION_2) ?
-        Array.from(new Set([
-          ...shaka.util.CmcdManager.CmcdKeys.V2CommonKeys,
-          ...shaka.util.CmcdManager.CmcdKeys.V2ResponseModeKeys,
-        ])) :
-        shaka.util.CmcdManager.CmcdKeys.V1Keys;
-
-    data.rc = response.status || 0;
-
-    const rawOutput = this.getGenericData_(
-        data,
-        shaka.util.CmcdManager.CmcdMode.RESPONSE,
-    );
-
-    if (response.headers && response.headers['CMSD-Static']) {
-      rawOutput.cmsds = btoa(response.headers['CMSD-Static']);
-    }
-
-    if (response.headers && response.headers['CMSD-Dynamic']) {
-      rawOutput.cmsdd = btoa(response.headers['CMSD-Dynamic']);
-    }
-
-    for (const target of responseTargets) {
-      const includeKeys = target.includeKeys || [];
-      const allowedKeysResponseMode = this.checkValidKeys_(
-          includeKeys,
-          allowedKeys,
-          shaka.util.CmcdManager.CmcdMode.RESPONSE,
-      );
-
-      const targetKey = this.getCmcdTargetHash_(target);
-      if (!this.cmcdSequenceNumbers_[targetKey]) {
-        this.cmcdSequenceNumbers_[targetKey] = {request: 1, response: 1};
-      }
-
-      rawOutput.sn = this.cmcdSequenceNumbers_[targetKey].response++;
-
-      const output = this.filterKeys_(rawOutput, allowedKeysResponseMode);
-
-      this.sendCmcdRequest_(output, target, response);
-    }
+    this.reportEvent_('rr', data);
   }
 
   /**
@@ -910,9 +879,8 @@ shaka.util.CmcdManager = class {
     }
 
     // Clean up timestamp entry after CMCD data has been attached to request
-    const hasResponseModeEnabled =
-        this.getResponseModeEnabledTargets().length > 0;
-    if (!hasResponseModeEnabled && this.requestTimestampMap_.has(request)) {
+    if (!this.hasResponseReceived_() &&
+          this.requestTimestampMap_.has(request)) {
       this.requestTimestampMap_.delete(request);
     }
   }
@@ -1672,13 +1640,10 @@ shaka.util.CmcdManager.CmcdKeys = {
     'ts', 'tpb', 'tb', 'lb', 'tab',
     'lab', 'pt', 'ec', 'msd', 'v',
   ],
-  V2ResponseModeKeys: [
-    'd', 'dl', 'nor', 'ot', 'rtp',
-    'rc', 'su', 'ttfb', 'ttfbb',
+  V2EventModeKeys: [
+    'e', 'sta', 'd', 'dl', 'nor', 'ot',
+    'rtp', 'rc', 'su', 'ttfb', 'ttfbb',
     'ttlb', 'url', 'cmsdd', 'cmsds',
-  ],
-  V2EventKeys: [
-    'e', 'sta',
   ],
   CmcdV2Events: [
     'ps',   // Play State: Change in Play State
@@ -1690,6 +1655,7 @@ shaka.util.CmcdManager.CmcdKeys = {
     'um',   // Unmute: Player unmuted
     'pe',   // Player Expand: Player view was expanded
     'pc',   // Player Collapse: Player view was collapsed
+    'rr',   // Response Received
   ],
   CmcdV2PlayStates: [
     's', // Start

--- a/test/util/cmcd_manager_unit.js
+++ b/test/util/cmcd_manager_unit.js
@@ -980,8 +980,7 @@ describe('CmcdManager Setup', () => {
     });
 
     describe('Configuration and Mode Handling', () => {
-      it('filters CMCD response mode keys correctly', () => {
-        // Set up spy for CMCD requests in event mode
+      it('filters CMCD response keys correctly', () => {
         const requestSpy = jasmine.createSpy('request');
         const networkingEngine = {
           request: requestSpy,
@@ -1002,7 +1001,7 @@ describe('CmcdManager Setup', () => {
                 mode: 'event',
                 enabled: true,
                 url: 'https://example.com/cmcd',
-                includeKeys: ['sid', 'cid', 'com.test-hello'],
+                includeKeys: ['rc', 'url'],
                 useHeaders: false,
                 events: ['rr'],
               }],
@@ -1026,14 +1025,8 @@ describe('CmcdManager Setup', () => {
 
 
         // Check that allowed keys are present
-        expect(decodedUri).toContain('sid=');
-        expect(decodedUri).toContain('cid=');
-
-        // Check that disallowed keys for event mode are not present
-        expect(decodedUri).not.toContain('v=2');
-        expect(decodedUri).not.toContain('msd=');
-        expect(decodedUri).not.toContain('ltc=');
-        expect(decodedUri).not.toContain('com.test-hello=');
+        expect(decodedUri).toContain('rc=');
+        expect(decodedUri).toContain('url=');
       });
 
       it('applies CMCD data to request URL in query mode', () => {
@@ -1059,7 +1052,6 @@ describe('CmcdManager Setup', () => {
       });
 
       it('applies CMCD data to response URL in query mode', () => {
-        // Set up spy for CMCD requests in event mode
         const requestSpy = jasmine.createSpy('request');
         const networkingEngine = {
           request: requestSpy,
@@ -1108,8 +1100,7 @@ describe('CmcdManager Setup', () => {
         expect(decodedUri).toContain('cid=');
       });
 
-      it('includes response code in response mode (query)', () => {
-        // Set up spy for CMCD requests in event mode
+      it('includes response code in response (query)', () => {
         const requestSpy = jasmine.createSpy('request');
         const networkingEngine = {
           request: requestSpy,
@@ -1153,7 +1144,6 @@ describe('CmcdManager Setup', () => {
       });
 
       it('includes response code in response headers', () => {
-        // Set up spy for CMCD requests in event mode
         const requestSpy = jasmine.createSpy('request');
         const networkingEngine = {
           request: requestSpy,
@@ -1196,7 +1186,6 @@ describe('CmcdManager Setup', () => {
       });
 
       it('does not include response code if not provided', () => {
-        // Set up spy for CMCD requests in event mode
         const requestSpy = jasmine.createSpy('request');
         const networkingEngine = {
           request: requestSpy,
@@ -1246,7 +1235,6 @@ describe('CmcdManager Setup', () => {
       });
 
       it('applies CMCD data to response headers in header mode', () => {
-        // Set up spy for CMCD requests in event mode
         const requestSpy = jasmine.createSpy('request');
         const networkingEngine = {
           request: requestSpy,
@@ -1293,8 +1281,7 @@ describe('CmcdManager Setup', () => {
             .toContain('v=2');
       });
 
-      it('applies v2 keys to response uri in response mode', () => {
-        // Set up spy for CMCD requests in event mode
+      it('applies v2 keys to response uri in response', () => {
         const requestSpy = jasmine.createSpy('request');
         const networkingEngine = {
           request: requestSpy,
@@ -1347,8 +1334,7 @@ describe('CmcdManager Setup', () => {
         expect(decodedUri).not.toContain('mtp=');
       });
 
-      it('filters keys in response mode based on includeKeys', () => {
-        // Set up spy for CMCD requests in event mode
+      it('filters keys in response based on includeKeys', () => {
         const requestSpy = jasmine.createSpy('request');
         const networkingEngine = {
           request: requestSpy,
@@ -1436,7 +1422,6 @@ describe('CmcdManager Setup', () => {
       });
 
       it('sn increments sequence number for each response', () => {
-        // Set up spy for CMCD requests in event mode
         const requestSpy = jasmine.createSpy('request');
         const networkingEngine = {
           request: requestSpy,
@@ -1490,7 +1475,6 @@ describe('CmcdManager Setup', () => {
       });
 
       it('sn increments sequence numbers across multiple targets', () => {
-        // Set up spy for CMCD requests in event mode
         const requestSpy = jasmine.createSpy('request');
         const networkingEngine = {
           request: requestSpy,
@@ -1570,7 +1554,6 @@ describe('CmcdManager Setup', () => {
       });
 
       it('sn ignores disabled response targets', () => {
-        // Set up spy for CMCD requests in event mode
         const requestSpy = jasmine.createSpy('request');
         const networkingEngine = {
           request: requestSpy,
@@ -1607,7 +1590,6 @@ describe('CmcdManager Setup', () => {
         );
         const spy = spyOn(cmcdManager, 'sendCmcdRequest_').and.callThrough();
 
-        // 2. Trigger the response data processing.
         cmcdManager.applyResponseData(
             shaka.net.NetworkingEngine.RequestType.SEGMENT,
             createResponse(),
@@ -1658,8 +1640,7 @@ describe('CmcdManager Setup', () => {
         expect(decodeURIComponent(request.uris[0])).toContain('ltc=');
       });
 
-      it('includes ltc for live content response mode', () => {
-        // Set up spy for CMCD requests in event mode
+      it('includes ltc for live content response', () => {
         const requestSpy = jasmine.createSpy('request');
         const networkingEngine = {
           request: requestSpy,
@@ -1727,7 +1708,6 @@ describe('CmcdManager Setup', () => {
       });
 
       it('sends msd only on the first response', () => {
-        // Set up spy for CMCD requests in event mode
         const requestSpy = jasmine.createSpy('request');
         const networkingEngine = {
           request: requestSpy,
@@ -1799,7 +1779,6 @@ describe('CmcdManager Setup', () => {
       });
 
       it('should generate sf for segment responses', () => {
-        // Set up spy for CMCD requests in event mode
         const requestSpy = jasmine.createSpy('request');
         const networkingEngine = {
           request: requestSpy,
@@ -1861,8 +1840,7 @@ describe('CmcdManager Setup', () => {
         expect(decoded2).not.toContain('bs');
       });
 
-      it('should generate bs after a rebuffering event response mode', () => {
-        // Set up spy for CMCD requests in event mode
+      it('should generate bs after a rebuffering event response', () => {
         const requestSpy = jasmine.createSpy('request');
         const networkingEngine = {
           request: requestSpy,
@@ -1953,21 +1931,8 @@ describe('CmcdManager Setup', () => {
         expect(decodedUri).toContain('rtp=');
       });
 
-      it('generates `nor` for URL-based segment requests', () => {
-        const cmcdManager = createCmcdManager(mockPlayer);
-        const request = createRequest();
-        const context =
-            createSegmentContextWithIndex(createMockNextSegment(false));
-
-        cmcdManager.applyRequestSegmentData(request, context);
-        const decodedUri = decodeURIComponent(request.uris[0]);
-
-        expect(decodedUri).toContain('nor="next-seg.m4v"');
-        expect(decodedUri).not.toContain('nrr=');
-      });
 
       it('generates `rtp` for segment responses', () => {
-        // Set up spy for CMCD requests in event mode
         const requestSpy = jasmine.createSpy('request');
         const networkingEngine = {
           request: requestSpy,
@@ -2007,7 +1972,6 @@ describe('CmcdManager Setup', () => {
       });
 
       it('sends ttfb and ttlb query', () => {
-        // Set up spy for CMCD requests in event mode
         const requestSpy = jasmine.createSpy('request');
         const networkingEngine = {
           request: requestSpy,
@@ -2051,7 +2015,6 @@ describe('CmcdManager Setup', () => {
       });
 
       it('sends ttfb and ttlb in headers', () => {
-        // Set up spy for CMCD requests in event mode
         const requestSpy = jasmine.createSpy('request');
         const networkingEngine = {
           request: requestSpy,
@@ -2093,7 +2056,6 @@ describe('CmcdManager Setup', () => {
       });
 
       it('does not generate ttfb or ttlb if timing info is missing', () => {
-        // Set up spy for CMCD requests in event mode
         const requestSpy = jasmine.createSpy('request');
         const networkingEngine = {
           request: requestSpy,
@@ -2137,7 +2099,6 @@ describe('CmcdManager Setup', () => {
       });
 
       it('generates nor for URL-based segment responses', () => {
-        // Set up spy for CMCD requests in event mode
         const requestSpy = jasmine.createSpy('request');
         const networkingEngine = {
           request: requestSpy,
@@ -2499,7 +2460,6 @@ describe('CmcdManager Setup', () => {
       });
 
       it('should send cmsdd in headers mode', () => {
-        // Set up spy for CMCD requests in event mode
         const requestSpy = jasmine.createSpy('request');
         const networkingEngine = {
           request: requestSpy,
@@ -2557,7 +2517,7 @@ describe('CmcdManager Setup', () => {
             .toContain(`cmsdd="${encodedCmsddData.toString()}"`);
       });
 
-      it('should not include "cmsdd" if header is not present', () => {
+      it('should not include cmsdd if header is not present', () => {
         const cmcdManager = createCmcdManager(
             mockPlayer,
             {
@@ -2622,7 +2582,7 @@ describe('CmcdManager Setup', () => {
       });
 
 
-      it('includes `bg` in request query when page is hidden', () => {
+      it('includes bg in request query when page is hidden', () => {
         Object.defineProperty(document, 'hidden',
             {value: true, configurable: true});
 
@@ -2636,7 +2596,7 @@ describe('CmcdManager Setup', () => {
         expect(`,${cmcdQuery},`).toContain(',bg,');
       });
 
-      it('includes `bg` in request headers when page is hidden', () => {
+      it('includes bg in request headers when page is hidden', () => {
         Object.defineProperty(document, 'hidden',
             {value: true, configurable: true});
 
@@ -2648,7 +2608,7 @@ describe('CmcdManager Setup', () => {
         expect(request.headers['CMCD-Status']).toContain('bg');
       });
 
-      it('does not include `bg` in request mode when page is visible', () => {
+      it('does not include bg in request mode when page is visible', () => {
         Object.defineProperty(document, 'hidden',
             {value: false, configurable: true});
 
@@ -2666,7 +2626,7 @@ describe('CmcdManager Setup', () => {
       });
 
 
-      it('assigns `bg` to the CMCD-Status header in request mode', () => {
+      it('assigns bg to the CMCD-Status header in request mode', () => {
         Object.defineProperty(document, 'hidden',
             {value: true, configurable: true});
 
@@ -2701,7 +2661,6 @@ describe('CmcdManager Setup', () => {
       });
 
       it('includes ts for segment responses', () => {
-        // Set up spy for CMCD requests in event mode
         const requestSpy = jasmine.createSpy('request');
         const networkingEngine = {
           request: requestSpy,
@@ -2777,7 +2736,6 @@ describe('CmcdManager Setup', () => {
       });
 
       it('reuses request timestamp for event mode', () => {
-        // Set up spy for CMCD requests in event mode
         const requestSpy = jasmine.createSpy('request');
         const networkingEngine = {
           request: requestSpy,
@@ -2991,7 +2949,7 @@ describe('CmcdManager Setup', () => {
       });
     });
 
-    it('should generate "cmsds" from response header', () => {
+    it('should generate cmsds from response header', () => {
       const cmcdManager = createCmcdManager(
           mockPlayer,
           {
@@ -3101,7 +3059,7 @@ describe('CmcdManager Setup', () => {
           .toContain(`cmsds="${encodedCmsdsData.toString()}"`);
     });
 
-    it('should not include "cmsds" if header is not present', () => {
+    it('should not include cmsds if header is not present', () => {
       const cmcdManager = createCmcdManager(
           mockPlayer,
           {

--- a/test/util/cmcd_manager_unit.js
+++ b/test/util/cmcd_manager_unit.js
@@ -919,7 +919,6 @@ describe('CmcdManager Setup', () => {
       includeKeys: [],
       version: 2,
       targets: [{
-        mode: 'event',
         enabled: true,
         url: 'https://example.com/cmcd-collector',
         useHeaders: false,
@@ -998,7 +997,6 @@ describe('CmcdManager Setup', () => {
               version: 2,
               enabled: true,
               targets: [{
-                mode: 'event',
                 enabled: true,
                 url: 'https://example.com/cmcd',
                 includeKeys: ['rc', 'url'],
@@ -1069,7 +1067,6 @@ describe('CmcdManager Setup', () => {
               version: 2,
               enabled: true,
               targets: [{
-                mode: 'event',
                 enabled: true,
                 url: 'https://example.com/cmcd',
                 includeKeys: ['sid', 'cid', 'v'],
@@ -1118,7 +1115,6 @@ describe('CmcdManager Setup', () => {
               version: 2,
               enabled: true,
               targets: [{
-                mode: 'event',
                 enabled: true,
                 url: 'https://example.com/cmcd',
                 includeKeys: ['rc'],
@@ -1161,7 +1157,6 @@ describe('CmcdManager Setup', () => {
               version: 2,
               enabled: true,
               targets: [{
-                mode: 'event',
                 enabled: true,
                 url: 'https://example.com/cmcd',
                 includeKeys: ['rc'],
@@ -1203,7 +1198,6 @@ describe('CmcdManager Setup', () => {
               version: 2,
               enabled: true,
               targets: [{
-                mode: 'event',
                 enabled: true,
                 url: 'https://example.com/cmcd',
                 includeKeys: ['rc', 'v'],
@@ -1252,7 +1246,6 @@ describe('CmcdManager Setup', () => {
               version: 2,
               enabled: true,
               targets: [{
-                mode: 'event',
                 enabled: true,
                 url: 'https://example.com/cmcd',
                 includeKeys: ['sid', 'v'],
@@ -1299,7 +1292,6 @@ describe('CmcdManager Setup', () => {
               version: 2,
               enabled: true,
               targets: [{
-                mode: 'event',
                 enabled: true,
                 url: 'https://example.com/cmcd-collector',
                 includeKeys: ['sid', 'cid', 'msd', 'ltc', 'v'],
@@ -1352,7 +1344,6 @@ describe('CmcdManager Setup', () => {
               version: 2,
               enabled: true,
               targets: [{
-                mode: 'event',
                 enabled: true,
                 url: 'https://example.com/cmcd-collector',
                 includeKeys: ['sid', 'msd'],
@@ -1439,7 +1430,6 @@ describe('CmcdManager Setup', () => {
               version: 2,
               enabled: true,
               targets: [{
-                mode: 'event',
                 enabled: true,
                 url: 'https://example.com/cmcd-collector',
                 includeKeys: ['sn'],
@@ -1493,7 +1483,6 @@ describe('CmcdManager Setup', () => {
               enabled: true,
               targets: [
                 {
-                  mode: 'event',
                   enabled: true,
                   url: 'https://a.collector.com/cmcd',
                   useHeaders: true,
@@ -1501,7 +1490,6 @@ describe('CmcdManager Setup', () => {
                   events: ['rr'],
                 },
                 {
-                  mode: 'event',
                   enabled: true,
                   url: 'https://b.collector.com/cmcd',
                   useHeaders: false,
@@ -1572,14 +1560,12 @@ describe('CmcdManager Setup', () => {
               enabled: true,
               targets: [
                 {
-                  mode: 'event',
                   enabled: true,
                   url: 'https://enabled.collector.com/cmcd',
                   includeKeys: ['sn'],
                   events: ['rr'],
                 },
                 {
-                  mode: 'event',
                   enabled: false,
                   url: 'https://disabled.collector.com/cmcd',
                   includeKeys: ['sn'],
@@ -1607,7 +1593,6 @@ describe('CmcdManager Setup', () => {
             {
               targets: [
                 {
-                  mode: 'event',
                   enabled: false,
                   url: 'https://disabled.collector.com/cmcd',
                   events: ['rr'],
@@ -1657,7 +1642,6 @@ describe('CmcdManager Setup', () => {
             {
               version: 2,
               targets: [{
-                mode: 'event',
                 enabled: true,
                 url: 'https://example.com/cmcd',
                 includeKeys: ['sid', 'msd', 'ltc'],
@@ -1988,7 +1972,6 @@ describe('CmcdManager Setup', () => {
             {
               version: 2,
               targets: [{
-                mode: 'event',
                 enabled: true,
                 url: 'https://example.com/cmcd',
                 includeKeys: ['ttfb', 'ttlb'],
@@ -2031,7 +2014,6 @@ describe('CmcdManager Setup', () => {
             {
               version: 2,
               targets: [{
-                mode: 'event',
                 enabled: true,
                 url: 'https://example.com/cmcd',
                 includeKeys: ['ttfb', 'ttlb'],
@@ -2072,7 +2054,6 @@ describe('CmcdManager Setup', () => {
             {
               version: 2,
               targets: [{
-                mode: 'event',
                 enabled: true,
                 url: 'https://example.com/cmcd',
                 includeKeys: ['ttfb', 'ttlb'],
@@ -2149,7 +2130,6 @@ describe('CmcdManager Setup', () => {
             {
               version: 2,
               targets: [{
-                mode: 'event',
                 enabled: true,
                 url: 'https://example.com/cmcd',
                 includeKeys: ['url'],
@@ -2203,7 +2183,6 @@ describe('CmcdManager Setup', () => {
         const cmcdManager = createCmcdManager(mockPlayerWithNE, {
           version: 2,
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
             includeKeys: ['url'],
@@ -2250,7 +2229,6 @@ describe('CmcdManager Setup', () => {
         const cmcdManager = createCmcdManager(mockPlayerWithNE, {
           version: 2,
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
             includeKeys: ['url'],
@@ -2300,7 +2278,6 @@ describe('CmcdManager Setup', () => {
         const cmcdManager = createCmcdManager(mockPlayerWithNE, {
           version: 2,
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
             includeKeys: ['url'],
@@ -2351,7 +2328,6 @@ describe('CmcdManager Setup', () => {
         const cmcdManager = createCmcdManager(mockPlayerWithNE, {
           version: 2,
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
             includeKeys: ['url'],
@@ -2675,7 +2651,6 @@ describe('CmcdManager Setup', () => {
         const cmcdManager = createCmcdManager(mockPlayerWithNE, {
           version: 2,
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
             includeKeys: ['ts'],
@@ -2714,7 +2689,6 @@ describe('CmcdManager Setup', () => {
         const cmcdManager = createCmcdManager(playerWithSpy, {
           version: 2,
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
             includeKeys: ['ts'],
@@ -2750,7 +2724,6 @@ describe('CmcdManager Setup', () => {
         const cmcdManager = createCmcdManager(mockPlayerWithNE, {
           version: 2,
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
             includeKeys: ['ts'],
@@ -2803,14 +2776,12 @@ describe('CmcdManager Setup', () => {
             {
               version: 2,
               targets: [{
-                mode: 'event',
                 enabled: true,
                 url: 'https://example.com/cmcd-query',
                 includeKeys: ['ts'],
                 useHeaders: false,
                 events: ['rr'],
               }, {
-                mode: 'event',
                 enabled: true,
                 url: 'https://example.com/cmcd-header',
                 includeKeys: ['ts'],
@@ -2880,7 +2851,6 @@ describe('CmcdManager Setup', () => {
           enabled: false,
           version: 2,
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd-query',
             includeKeys: ['ts'],
@@ -3121,7 +3091,6 @@ describe('CmcdManager Setup', () => {
           version: 2,
           enabled: true,
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
             includeKeys: ['e', 'sta', 'v'],
@@ -3175,7 +3144,6 @@ describe('CmcdManager Setup', () => {
           version: 2,
           enabled: true,
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
             includeKeys: ['e', 'sta', 'v'],
@@ -3220,7 +3188,6 @@ describe('CmcdManager Setup', () => {
             version: 2,
             enabled: true,
             targets: [{
-              mode: 'event',
               enabled: true,
               url: 'https://example.com/cmcd',
               timeInterval: 1,
@@ -3251,7 +3218,6 @@ describe('CmcdManager Setup', () => {
             version: 2,
             enabled: true,
             targets: [{
-              mode: 'event',
               enabled: true,
               url: 'https://example.com/cmcd',
               timeInterval: 0,
@@ -3279,7 +3245,6 @@ describe('CmcdManager Setup', () => {
             version: 2,
             enabled: true,
             targets: [{
-              mode: 'event',
               enabled: true,
               url: 'https://example.com/cmcd',
               // timeInterval is not defined, should default to 10s.
@@ -3315,7 +3280,6 @@ describe('CmcdManager Setup', () => {
             mockPlayerWithNE,
             {
               targets: [{
-                mode: 'event',
                 enabled: true,
                 url: 'https://example.com/cmcd',
                 includeKeys: ['msd', 'e', 'sta'],
@@ -3365,7 +3329,6 @@ describe('CmcdManager Setup', () => {
           version: 2,
           enabled: true,
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
             includeKeys: ['e', 'sta'],
@@ -3418,7 +3381,6 @@ describe('CmcdManager Setup', () => {
           sessionId: sessionId,
           contentId: 'v2-event-content',
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
             includeKeys: ['e', 'sta', 'bl', 'mtp', 'cid'],
@@ -3458,7 +3420,6 @@ describe('CmcdManager Setup', () => {
           version: 2,
           enabled: true,
           targets: [{
-            mode: 'event',
             enabled: false, // Target is disabled
             url: 'https://example.com/cmcd',
           }],
@@ -3478,7 +3439,6 @@ describe('CmcdManager Setup', () => {
           version: 1, // CMCD v1
           enabled: true,
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
           }],
@@ -3498,7 +3458,6 @@ describe('CmcdManager Setup', () => {
           version: 2,
           enabled: true,
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
             // d and rtp are not valid for event mode
@@ -3542,14 +3501,12 @@ describe('CmcdManager Setup', () => {
           enabled: true,
           targets: [
             {
-              mode: 'event',
               enabled: true,
               url: 'https://example.com/cmcd1',
               includeKeys: ['e', 'sta'],
               events: ['ps'],
             },
             {
-              mode: 'event',
               enabled: true,
               url: 'https://example.com/cmcd2',
               includeKeys: ['e', 'sta', 'v'],
@@ -3617,7 +3574,6 @@ describe('CmcdManager Setup', () => {
           enabled: true,
           sessionId: sessionId,
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
             includeKeys: ['e', 'sta', 'v', 'sid'],
@@ -3660,7 +3616,6 @@ describe('CmcdManager Setup', () => {
           version: 2,
           enabled: true,
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
             includeKeys: ['e', 'sta', 'ts'],
@@ -3683,8 +3638,8 @@ describe('CmcdManager Setup', () => {
 
       it('should return only enabled event targets', () => {
         const targets = [
-          {mode: 'event', enabled: true, url: 'url1'},
-          {mode: 'event', enabled: false, url: 'url2'},
+          {enabled: true, url: 'url1'},
+          {enabled: false, url: 'url2'},
         ];
         const cmcdManager = createCmcdManager(mockPlayer, {targets});
         const enabledEventTargets = cmcdManager.getEventModeEnabledTargets_();
@@ -3700,7 +3655,7 @@ describe('CmcdManager Setup', () => {
 
       it('should return an empty array if no event targets are enabled', () => {
         const targets = [
-          {mode: 'event', enabled: false, url: 'url1'},
+          {enabled: false, url: 'url1'},
         ];
         const cmcdManager = createCmcdManager(mockPlayer, {targets});
         const enabledEventTargets = cmcdManager.getEventModeEnabledTargets_();
@@ -3713,7 +3668,6 @@ describe('CmcdManager Setup', () => {
           version: 2,
           enabled: true,
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
             // rc, url, ttfb and ttlb are not valid for event mode
@@ -3746,7 +3700,6 @@ describe('CmcdManager Setup', () => {
           version: 2,
           enabled: true,
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
             includeKeys: ['e', 'sta'], // ts is omitted
@@ -3774,7 +3727,6 @@ describe('CmcdManager Setup', () => {
           sessionId: sessionId,
           contentId: 'v2-event-content',
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
             includeKeys: [],
@@ -3821,7 +3773,6 @@ describe('CmcdManager Setup', () => {
           version: 2,
           enabled: true,
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
             includeKeys: ['e', 'sta'],
@@ -3877,7 +3828,6 @@ describe('CmcdManager Setup', () => {
           sessionId: sessionId,
           contentId: 'v2-event-content-all',
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
             includeKeys: [],
@@ -3934,7 +3884,6 @@ describe('CmcdManager Setup', () => {
           version: 2,
           enabled: true,
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
             includeKeys: ['e', 'sta', 'v'],
@@ -3970,7 +3919,6 @@ describe('CmcdManager Setup', () => {
           version: 2,
           enabled: true,
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
             includeKeys: ['e', 'sta'],
@@ -4004,7 +3952,6 @@ describe('CmcdManager Setup', () => {
           version: 2,
           enabled: true,
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
             includeKeys: ['e'],
@@ -4060,7 +4007,6 @@ describe('CmcdManager Setup', () => {
           version: 2,
           enabled: true,
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
             includeKeys: ['e', 'sta', 'v'],
@@ -4095,7 +4041,6 @@ describe('CmcdManager Setup', () => {
           version: 2,
           enabled: true,
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
             includeKeys: ['e', 'sta', 'v'],
@@ -4131,7 +4076,6 @@ describe('CmcdManager Setup', () => {
           version: 2,
           enabled: true,
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
             includeKeys: ['e'],
@@ -4183,7 +4127,6 @@ describe('CmcdManager Setup', () => {
           version: 2,
           enabled: true,
           targets: [{
-            mode: 'event',
             enabled: true,
             url: 'https://example.com/cmcd',
             includeKeys: ['e'],

--- a/test/util/cmcd_manager_unit.js
+++ b/test/util/cmcd_manager_unit.js
@@ -4193,7 +4193,7 @@ describe('CmcdManager Setup', () => {
                   enabled: true,
                   url: 'https://target2.com/cmcd',
                   includeKeys: ['e', 'sta', 'ts'],
-                  events: ['ps'], // Playstate events
+                  events: ['ps'], // Player state events
                 },
               ],
             };


### PR DESCRIPTION
## Summary of Changes

This pull request significantly refactors the CMCD Manager by deprecating 'response mode' and instead leveraging a new 'response received' (rr) event within the existing event-based reporting system. 

### Highlights

* **Refactored CMCD Response Handling**: The explicit 'response mode' has been removed and its functionality integrated into a new 'response received' (rr) event. 
* **Consolidated CMCD V2 Keys**: The `V2ResponseModeKeys` have been merged into `V2EventModeKeys`.
* **Enhanced Event Data**: Response status (`rc`) and CMSD headers (`cmsds`, `cmsdd`) are now directly included in the data payload for the new `rr` event, ensuring comprehensive reporting.
* **Sequence Number Tracking**: Sequence number (`sn`) logic has been implemented for response events, allowing for better tracking of event order across multiple targets.
* **Updated Test Suite**: Unit tests have been extensively updated to reflect the new event-driven architecture, verifying CMCD data through networking engine spies and including new tests for multiple target handling and independent state management.

<details>
<summary><b>Changelog</b></summary>

* **lib/util/cmcd_manager.js**
    * Removed `response` property from `this.msdSent_` object.
    * Refactored `applyResponseData` to trigger a new `rr` event, incorporating previous response mode logic.
    * Integrated response status (`data.rc`) and CMSD headers (`data.cmsds`, `data.cmsdd`) into the `rr` event data payload.
    * Updated `reportEvent_` calls to use consistent quoted keys for object literals (e.g., `'sta': 'r'`).
    * Consolidated CMCD V2 key definitions by merging `V2ResponseModeKeys` into `V2EventModeKeys` .
    * Added `'rr'` (Response Received) to the list of `CmcdV2Events`.
    * Implemented sequence number (`sn`) tracking for response events within `reportEvent_`.
    * Added logic to clean up `requestTimestampMap_` entries if no `rr` event is configured for a request.
    * Renamed `getResponseModeEnabledTargets()` to `hasResponseReceived_()` and updated its logic to check for the `rr` event in target configurations.
* **test/util/cmcd_manager_unit.js**
    * Adapted numerous unit tests to align with the new event-driven approach, specifically for `rr` events.
    * Modified test assertions to verify CMCD data through `networkingEngine` spies, reflecting the internal request mechanism for event reporting.
    * Introduced new test cases to validate the handling of multiple CMCD targets and the independent state management for sequence numbers across these targets.
    * Updated test configurations to remove `mode: 'response'` and include `events: ['rr']` where applicable.
</details>